### PR TITLE
docs: update documentation for maplibre-geoman v0.6.0

### DIFF
--- a/docs/10-importing-data.md
+++ b/docs/10-importing-data.md
@@ -13,7 +13,7 @@ In this case we have hardcoded a Geojson feature in the `export const demoFeatur
 ` const. This could be fetched from an API or a file or a database.
 
 ```js
-export const demoFeature: GeoJsonImportFeature = 
+export const demoFeature: GeoJsonImportFeature =
   {
     type: 'Feature',
     properties: {
@@ -85,6 +85,28 @@ fc.features.forEach((feature) => {
 gm.features.importGeoJson(fc);
 ```
 
+### Using the overwrite option
+
+When importing GeoJSON features that may have IDs matching existing features, you can use the `overwrite` option to replace them:
+
+```js
+// Import with overwrite enabled - existing features with matching IDs will be replaced
+const result = gm.features.importGeoJson(fc, { overwrite: true });
+
+console.log(result.stats.overwritten); // Number of features that were replaced
+```
+
+When `overwrite: true` is set, existing features with matching IDs are deleted before importing the new features. The `stats.overwritten` count in the result tracks how many features were replaced.
+
+### Using a custom ID property
+
+You can specify which property to use as the feature ID during import:
+
+```js
+// Use the 'customId' property from feature.properties as the feature ID
+const result = gm.features.importGeoJson(fc, { idPropertyName: 'customId' });
+```
+
 ## Full Demo example
 
 We have put together a list of examples from the Maplibre-Geoman Examples Repository that showcase how to import Geojson data into the map. All the examples import features from a fixtures file and add them to the map using the `gm.features.importGeoJsonFeature` method.
@@ -92,6 +114,17 @@ We have put together a list of examples from the Maplibre-Geoman Examples Reposi
 See the [Examples](/examples) page for more information.
 
 ## API Reference
+
+### ImportGeoJsonOptions
+
+```ts
+interface ImportGeoJsonOptions {
+  idPropertyName?: string;  // Use a specific property as the feature ID
+  overwrite?: boolean;      // When true, replace existing features with matching IDs
+}
+```
+
+### GeoJsonImportFeature
 
 ```ts
 interface GeoJsonImportFeature {
@@ -104,5 +137,19 @@ interface GeoJsonImportFeature {
     type: string;
     coordinates: any[];
   };
+}
+```
+
+### Import Result
+
+```ts
+interface ImportGeoJsonResult {
+  stats: {
+    total: number;      // Total features processed
+    success: number;    // Successfully imported features
+    failed: number;     // Features that failed to import
+    overwritten: number; // Features replaced (when overwrite: true)
+  };
+  addedFeatures: Array<FeatureData>; // The imported FeatureData instances
 }
 ```

--- a/docs/107-features-instance.md
+++ b/docs/107-features-instance.md
@@ -55,16 +55,22 @@ Imports GeoJSON data and creates features.
 ```typescript
 features.importGeoJson(
   geoJson: GeoJsonImportFeatureCollection | GeoJsonImportFeature,
-  idPropertyName?: string  // Optional: use a specific property as the feature ID
+  options?: {
+    idPropertyName?: string;  // Use a specific property as the feature ID
+    overwrite?: boolean;      // When true, replace existing features with matching IDs
+  }
 ): {
   stats: {
     total: number;
     success: number;
     failed: number;
+    overwritten: number;  // Count of replaced features (when overwrite: true)
   };
   addedFeatures: Array<FeatureData>;
 };
 ```
+
+When `overwrite: true` is set, existing features with matching IDs are deleted before importing the new features.
 
 #### `importGeoJsonFeature`
 Imports a single GeoJSON feature.
@@ -73,9 +79,18 @@ features.importGeoJsonFeature(shapeGeoJson: GeoJsonImportFeature): FeatureData |
 ```
 
 #### `exportGeoJson`
-Exports all features as a GeoJSON FeatureCollection.
+Exports all features as a GeoJSON FeatureCollection from Geoman's internal state. This provides the latest feature data, even during event handlers before MapLibre has committed changes.
 ```typescript
 features.exportGeoJson(options?: {
+  allowedShapes?: Array<FeatureShape>;  // Filter by shape types
+  idPropertyName?: string;               // Custom property name for IDs
+}): GeoJsonShapeFeatureCollection;
+```
+
+#### `exportGeoJsonFromSource`
+Exports all features as a GeoJSON FeatureCollection directly from MapLibre's source. This may lag slightly behind Geoman's internal state during rapid updates or in event handlers.
+```typescript
+features.exportGeoJsonFromSource(options?: {
   allowedShapes?: Array<FeatureShape>;  // Filter by shape types
   idPropertyName?: string;               // Custom property name for IDs
 }): GeoJsonShapeFeatureCollection;
@@ -198,6 +213,95 @@ Geoman has three built-in sources for features:
 - `gm_temporary`: For temporary features during editing/drawing
 - `gm_standby`: For standby features (Pro version only)
 
+## FeatureData Instance Methods
+
+Once you have a `FeatureData` instance (from importing, creating, or querying features), you can call the following methods directly on the feature instance.
+
+### `updateProperties`
+Updates custom properties on this feature. Properties are merged with existing ones. Set a property value to `undefined` to delete it. Internal Geoman properties (prefixed with `gm_`) are protected and cannot be modified through this method.
+```typescript
+feature.updateProperties(properties: Record<string, unknown>): void;
+```
+
+**Example:**
+```typescript
+// Get a feature
+const feature = gm.features.get('gm_main', featureId);
+
+// Update properties (merged with existing)
+feature.updateProperties({
+  name: 'Updated Name',
+  description: 'New description',
+  oldProperty: undefined  // This deletes the property
+});
+```
+
+### `setProperties`
+Replaces all custom properties on this feature. Removes existing custom properties and replaces them with the provided ones. Internal Geoman properties (prefixed with `gm_`) are preserved and cannot be removed.
+```typescript
+feature.setProperties(properties: Record<string, unknown>): void;
+```
+
+**Example:**
+```typescript
+// Get a feature
+const feature = gm.features.get('gm_main', featureId);
+
+// Replace all custom properties
+feature.setProperties({
+  name: 'New Name',
+  category: 'residential'
+});
+// Previous custom properties are removed, only 'name' and 'category' remain
+```
+
+### `updateGeometry`
+Updates the geometry of this feature with new coordinates.
+```typescript
+feature.updateGeometry(geometry: BasicGeometry): void;
+```
+
+**Example:**
+```typescript
+// Get a feature
+const feature = gm.features.get('gm_main', featureId);
+
+// Update the geometry
+feature.updateGeometry({
+  type: 'Polygon',
+  coordinates: [
+    [
+      [-8.15, 49.44],
+      [-8.10, 49.44],
+      [-8.10, 49.40],
+      [-8.15, 49.40],
+      [-8.15, 49.44]
+    ]
+  ]
+});
+```
+
+### `delete`
+Removes this feature and its associated markers from the map.
+```typescript
+feature.delete(): void;
+```
+
+### `convertToPolygon`
+Converts circle, ellipse, or rectangle shapes to standard polygon form by removing shape-specific properties. Returns `true` if conversion was successful.
+```typescript
+feature.convertToPolygon(): boolean;
+```
+
+### `changeSource`
+Moves this feature to a different source.
+```typescript
+feature.changeSource({
+  sourceName: FeatureSourceName;
+  atomic: boolean;
+}): void;
+```
+
 ## Types
 
 ### FeatureData
@@ -211,6 +315,14 @@ interface FeatureData {
   shapeProperties: FeatureShapeProperties;
   source: BaseSource;
   orders: FeatureOrders;
+
+  // Instance methods
+  updateProperties(properties: Record<string, unknown>): void;
+  setProperties(properties: Record<string, unknown>): void;
+  updateGeometry(geometry: BasicGeometry): void;
+  delete(): void;
+  convertToPolygon(): boolean;
+  changeSource(options: { sourceName: FeatureSourceName; atomic: boolean }): void;
 }
 ```
 
@@ -242,13 +354,20 @@ const geoJson = {
 // Import features
 const result = gm.features.importGeoJson(geoJson);
 
+// Import with overwrite option (replaces existing features with matching IDs)
+const resultWithOverwrite = gm.features.importGeoJson(geoJson, { overwrite: true });
+console.log(`Overwritten: ${resultWithOverwrite.stats.overwritten} features`);
+
 // Iterate over features
 gm.features.forEach((feature) => {
   console.log(feature.id, feature.shape);
 });
 
-// Export features
+// Export features from Geoman's internal state
 const exported = gm.features.exportGeoJson();
+
+// Export features directly from MapLibre's source
+const exportedFromSource = gm.features.exportGeoJsonFromSource();
 
 // Get features in bounds
 const bounds: [ScreenPoint, ScreenPoint] = [[0, 0], [100, 100]];
@@ -256,4 +375,28 @@ const featuresInBounds = gm.features.getFeaturesByScreenBounds({
   bounds,
   sourceNames: ['gm_main']
 });
+
+// Working with individual feature instances
+const feature = gm.features.get('gm_main', 'feature-id');
+if (feature) {
+  // Update properties (merges with existing)
+  feature.updateProperties({
+    name: 'Updated Feature',
+    status: 'active'
+  });
+
+  // Replace all properties
+  feature.setProperties({
+    name: 'New Name Only'
+  });
+
+  // Update geometry
+  feature.updateGeometry({
+    type: 'Point',
+    coordinates: [10, 20]
+  });
+
+  // Delete the feature
+  // feature.delete();
+}
 ```

--- a/docs/11-exporting-data.md
+++ b/docs/11-exporting-data.md
@@ -12,7 +12,37 @@ The simplest way to export all features is using `exportGeoJson()`:
 const allFeatures = gm.features.exportGeoJson();
 ```
 
-This returns a GeoJSON FeatureCollection containing all features from all sources.
+This returns a GeoJSON FeatureCollection containing all features from Geoman's internal state. This method provides the latest feature data, even during event handlers before MapLibre has committed changes.
+
+### Export from MapLibre Source
+
+If you need to export features directly from MapLibre's source (which may lag slightly behind during rapid updates or in event handlers), use `exportGeoJsonFromSource()`:
+
+```typescript
+const featuresFromSource = gm.features.exportGeoJsonFromSource();
+```
+
+### Export with Options
+
+Both export methods support filtering by shape types and customizing the ID property name:
+
+```typescript
+// Export only polygons and circles
+const polygonsAndCircles = gm.features.exportGeoJson({
+  allowedShapes: ['polygon', 'circle']
+});
+
+// Use a custom property name for feature IDs
+const withCustomId = gm.features.exportGeoJson({
+  idPropertyName: 'featureId'
+});
+
+// Combine options
+const filtered = gm.features.exportGeoJsonFromSource({
+  allowedShapes: ['marker', 'line'],
+  idPropertyName: 'customId'
+});
+```
 
 ## Exported GeoJSON Structure
 


### PR DESCRIPTION
## Summary
- Document the new `overwrite` option for `importGeoJson()` that replaces existing features with matching IDs
- Add documentation for `exportGeoJsonFromSource()` method for exporting directly from MapLibre's source
- Add comprehensive documentation for new `FeatureData` instance methods: `updateProperties`, `setProperties`, `updateGeometry`
- Include TypeScript interfaces and practical examples for all new features

## Changes
- `docs/10-importing-data.md`: Added overwrite option, custom ID property usage, and updated API reference with `ImportGeoJsonOptions` and `ImportGeoJsonResult` interfaces
- `docs/107-features-instance.md`: Updated `importGeoJson` signature, added `exportGeoJsonFromSource`, new FeatureData Instance Methods section with full documentation
- `docs/11-exporting-data.md`: Added `exportGeoJsonFromSource` documentation and export options examples

## Test plan
- [ ] Verify documentation renders correctly on the docs site
- [ ] Confirm code examples are syntactically correct
- [ ] Check that all new API methods are properly documented