### PR TITLE
Add llms.txt spec-compliant documentation setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# Generated LLM files
+/static/llms.txt
+/static/llms-full.txt

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 engine-strict=true
 @geoman-io:registry=https://npm.geoman.io/
+//npm.geoman.io/:_authToken=${NPM_TOKEN_GEOMAN}

--- a/docs/01-basics.md
+++ b/docs/01-basics.md
@@ -1,5 +1,6 @@
 ---
 title: "Basic Usage and Installation"
+description: "Installation guide, basic setup, and initialization for the free and pro versions of MapLibre-Geoman."
 ---
 
 # Basic Usage

--- a/docs/02-configuring-geoman.md
+++ b/docs/02-configuring-geoman.md
@@ -1,3 +1,8 @@
+---
+title: "Configuring Geoman"
+description: "Configure Geoman controls, styles, settings, and layer behaviors through the options object."
+---
+
 # Configuring Geoman
 
 Geoman can be configured by passing an options object to the Geoman constructor. The configuration allows you to customize various aspects of the library, including controls, styles, and general settings.

--- a/docs/03-events.md
+++ b/docs/03-events.md
@@ -1,3 +1,8 @@
+---
+title: "Geoman Events"
+description: "Event system reference for listening to draw, edit, drag, cut, rotate, and other geometry interactions."
+---
+
 # Geoman Events
 
 Geoman provides a rich event system that allows you to listen to various interactions with the map. Events can be listened to either individually or globally.

--- a/docs/04-mode-switching.md
+++ b/docs/04-mode-switching.md
@@ -1,5 +1,6 @@
 ---
 title: "Modes Handling"
+description: "Enable, disable, and toggle draw, edit, and helper modes using the mode handling API."
 ---
 
 # Mode Handling

--- a/docs/10-importing-data.md
+++ b/docs/10-importing-data.md
@@ -1,5 +1,6 @@
 ---
 title: "Importing Geojson"
+description: "Import existing GeoJSON data into the map using importGeoJsonFeature and importGeoJson methods."
 ---
 
 # Importing existing Geojson data

--- a/docs/104-examples.md
+++ b/docs/104-examples.md
@@ -1,5 +1,6 @@
 ---
 title: "Examples"
+description: "Runnable code examples demonstrating common MapLibre-Geoman use cases."
 ---
 
 # Maplibre-Geoman Examples

--- a/docs/105-geoman-instance-api.md
+++ b/docs/105-geoman-instance-api.md
@@ -1,3 +1,8 @@
+---
+title: "Geoman Instance API"
+description: "Complete API reference for the Geoman instance: initialization, mode management, global controls, and feature operations."
+---
+
 # Geoman Instance API
 
 The Geoman instance provides the main interface for interacting with the map editing functionality. This documentation covers all public methods available on the Geoman instance.

--- a/docs/106-geoman-options-api.md
+++ b/docs/106-geoman-options-api.md
@@ -1,3 +1,7 @@
+---
+title: "Geoman Options API"
+description: "API reference for GmOptions: control configuration, mode state management, settings, and layer styles."
+---
 
 # Geoman Options API
 

--- a/docs/107-features-instance.md
+++ b/docs/107-features-instance.md
@@ -1,3 +1,8 @@
+---
+title: "Geoman Features API"
+description: "API reference for the Features instance: importing, exporting, querying, and manipulating map features."
+---
+
 # Geoman Features API
 
 The Features API provides methods to manage and manipulate features (geometries) on the map. It is accessible through the `features` property on the Geoman instance.

--- a/docs/11-exporting-data.md
+++ b/docs/11-exporting-data.md
@@ -1,3 +1,8 @@
+---
+title: "Exporting GeoJSON"
+description: "Export features as GeoJSON FeatureCollections with filtering by source, shape type, or specific features."
+---
+
 # Exporting GeoJSON
 
 Geoman provides several methods to export features as GeoJSON. You can export all features, features from specific sources, or filtered features based on shape types.

--- a/docs/12-feature-ids.md
+++ b/docs/12-feature-ids.md
@@ -1,3 +1,8 @@
+---
+title: "Feature IDs"
+description: "How Geoman assigns, tracks, and manages feature IDs during import, export, and editing."
+---
+
 # Feature IDs in Geoman
 
 Geoman uses feature IDs to track and manage features on the map. Understanding how these IDs work is important for importing, exporting, and managing features.

--- a/docs/draw-modes/00-draw-marker.mdx
+++ b/docs/draw-modes/00-draw-marker.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Draw Marker"
+description: "Add point markers to the map by clicking on locations."
 ---
 
 # Draw Marker Mode

--- a/docs/draw-modes/01-draw-circle_marker.mdx
+++ b/docs/draw-modes/01-draw-circle_marker.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Draw Circle Marker"
+description: "Add circle markers with a fixed pixel radius to the map."
 ---
 
 # Draw Circle Marker Mode

--- a/docs/draw-modes/02-draw-text_marker.mdx
+++ b/docs/draw-modes/02-draw-text_marker.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Draw Text Marker"
+description: "Add text labels to the map by clicking and entering custom text."
 ---
 
 # Draw Text Marker Mode

--- a/docs/draw-modes/03-draw-circle.mdx
+++ b/docs/draw-modes/03-draw-circle.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Draw Circle"
+description: "Draw circles on the map by defining a center point and radius."
 ---
 
 # Draw Circle Mode

--- a/docs/draw-modes/03a-draw-ellipse.mdx
+++ b/docs/draw-modes/03a-draw-ellipse.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Draw Ellipse"
+description: "Draw ellipses on the map by defining a center point and two semi-axis radii."
 ---
 
 # Draw Ellipse Mode

--- a/docs/draw-modes/04-draw-line.mdx
+++ b/docs/draw-modes/04-draw-line.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Draw Line"
+description: "Draw polylines on the map by clicking to place vertices."
 ---
 
 # Draw Line Mode

--- a/docs/draw-modes/05-draw-rectangle.mdx
+++ b/docs/draw-modes/05-draw-rectangle.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Draw Rectangle"
+description: "Draw rectangles on the map by clicking two corner points."
 ---
 
 # Draw Rectangle Mode

--- a/docs/draw-modes/06-draw-polygon.mdx
+++ b/docs/draw-modes/06-draw-polygon.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Draw Polygon"
+description: "Draw polygons on the map by clicking to place vertices and closing the shape."
 ---
 
 # Draw Polygon Mode

--- a/docs/draw-modes/07-draw-freehand.mdx
+++ b/docs/draw-modes/07-draw-freehand.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Draw Freehand ⭐"
+description: "Draw freehand shapes on the map by clicking and dragging."
 ---
 
 # Draw Freehand Mode ⭐

--- a/docs/draw-modes/08-draw-custom_shape.mdx
+++ b/docs/draw-modes/08-draw-custom_shape.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Draw Custom Shape ⭐"
+description: "Draw custom predefined shapes like arrows or stars using GeoJSON templates."
 ---
 
 # Draw Custom Shape Mode ⭐

--- a/docs/edit-modes/00-edit-drag.mdx
+++ b/docs/edit-modes/00-edit-drag.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Drag"
+description: "Drag and reposition features on the map."
 ---
 
 # Drag Mode

--- a/docs/edit-modes/01-edit-change.mdx
+++ b/docs/edit-modes/01-edit-change.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Edit"
+description: "Edit feature vertices to change the geometry shape."
 ---
 
 # Edit Mode

--- a/docs/edit-modes/02-edit-rotate.mdx
+++ b/docs/edit-modes/02-edit-rotate.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Rotate"
+description: "Rotate features around their center point."
 ---
 
 # Rotate Mode

--- a/docs/edit-modes/03-edit-scale.mdx
+++ b/docs/edit-modes/03-edit-scale.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Scale ⭐"
+description: "Scale features to resize them proportionally."
 ---
 
 # Scale Mode

--- a/docs/edit-modes/04-edit-copy.mdx
+++ b/docs/edit-modes/04-edit-copy.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Copy ⭐"
+description: "Copy features to duplicate them on the map."
 ---
 
 # Copy Mode

--- a/docs/edit-modes/05-edit-cut.mdx
+++ b/docs/edit-modes/05-edit-cut.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Cut"
+description: "Cut and subtract geometry from existing features."
 ---
 
 # Cut Mode

--- a/docs/edit-modes/06-edit-split.mdx
+++ b/docs/edit-modes/06-edit-split.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Split ⭐"
+description: "Split features into multiple parts using a cutting line."
 ---
 
 # Split Mode

--- a/docs/edit-modes/07-edit-union.mdx
+++ b/docs/edit-modes/07-edit-union.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Union ⭐"
+description: "Merge overlapping features into a single combined geometry."
 ---
 
 # Union Mode

--- a/docs/edit-modes/08-edit-difference.mdx
+++ b/docs/edit-modes/08-edit-difference.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Difference ⭐"
+description: "Compute the geometric difference between overlapping features."
 ---
 
 # Difference Mode

--- a/docs/edit-modes/09-edit-line_simplification.mdx
+++ b/docs/edit-modes/09-edit-line_simplification.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Line Simplification ⭐"
+description: "Simplify polyline and polygon vertices to reduce complexity."
 ---
 
 # Line Simplification Mode

--- a/docs/edit-modes/10-edit-lasso.mdx
+++ b/docs/edit-modes/10-edit-lasso.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Lasso ⭐"
+description: "Select multiple features by drawing a freehand lasso selection area."
 ---
 
 # Lasso Mode

--- a/docs/edit-modes/11-edit-delete.mdx
+++ b/docs/edit-modes/11-edit-delete.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Remove"
+description: "Delete features from the map."
 ---
 
 # Remove Mode

--- a/docs/helper-modes/00-helper-snapping.mdx
+++ b/docs/helper-modes/00-helper-snapping.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Snapping"
+description: "Snap features to nearby vertices and edges during drawing and editing."
 ---
 
 # Snapping Helper Mode

--- a/docs/helper-modes/01-helper-snap_guides.mdx
+++ b/docs/helper-modes/01-helper-snap_guides.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Snap Guides ⭐"
+description: "Display alignment guides when drawing or editing features."
 ---
 
 # Snap Guides Helper Mode

--- a/docs/helper-modes/02-helper-measurements.mdx
+++ b/docs/helper-modes/02-helper-measurements.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Measurements ⭐"
+description: "Display live distance, area, and perimeter measurements during drawing and editing."
 ---
 
 # Measurements Helper Mode

--- a/docs/helper-modes/03-helper-pin.mdx
+++ b/docs/helper-modes/03-helper-pin.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Pin ⭐"
+description: "Pin markers to specific positions that persist across interactions."
 ---
 
 # Pin Helper Mode

--- a/docs/helper-modes/04-helper-auto_trace.mdx
+++ b/docs/helper-modes/04-helper-auto_trace.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Auto Trace ⭐"
+description: "Automatically trace along existing feature edges when drawing new shapes."
 ---
 
 # Auto Trace Helper Mode

--- a/docs/helper-modes/05-helper-zoom_to_features.mdx
+++ b/docs/helper-modes/05-helper-zoom_to_features.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Zoom to Features"
+description: "Zoom the map viewport to fit selected features."
 ---
 
 # Zoom to Features Helper Mode

--- a/package-lock.json
+++ b/package-lock.json
@@ -238,7 +238,6 @@
       "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.46.0.tgz",
       "integrity": "sha512-22SHEEVNjZfFWkFks3P6HilkR3rS7a6GjnCIqR22Zz4HNxdfT0FG+RE7efTcFVfLUkTTMQQybvaUcwMrHXYa7Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@algolia/client-common": "5.46.0",
         "@algolia/requester-browser-xhr": "5.46.0",
@@ -364,7 +363,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -2154,7 +2152,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2177,7 +2174,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2287,7 +2283,6 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -2709,7 +2704,6 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -3644,7 +3638,6 @@
       "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.9.2.tgz",
       "integrity": "sha512-C5wZsGuKTY8jEYsqdxhhFOe1ZDjH0uIYJ9T/jebHwkyxqnr4wW0jTkB72OMqNjsoQRcb0JN3PcSeTwFlVgzCZg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@docusaurus/core": "3.9.2",
         "@docusaurus/logger": "3.9.2",
@@ -4506,7 +4499,6 @@
       "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-3.1.1.tgz",
       "integrity": "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/mdx": "^2.0.0"
       },
@@ -4825,7 +4817,6 @@
       "resolved": "https://registry.npmjs.org/@svgr/core/-/core-8.1.0.tgz",
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -5964,7 +5955,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.4.tgz",
       "integrity": "sha512-J7W30FTdfCxDDjmfRM+/JqLHBIyl7xUIp9kwK637FGmY7+mkSFSe6L4jpZzhj5QMfLssSDP4/i75AKkrdC7/Jw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -6332,7 +6322,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
       "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6406,7 +6395,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -6452,7 +6440,6 @@
       "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.46.0.tgz",
       "integrity": "sha512-7ML6fa2K93FIfifG3GMWhDEwT5qQzPTmoHKCTvhzGEwdbQ4n0yYUWZlLYT75WllTGJCJtNUI0C1ybN4BCegqvg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@algolia/abtesting": "1.12.0",
         "@algolia/client-abtesting": "5.46.0",
@@ -6937,7 +6924,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -7894,7 +7880,6 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -9298,7 +9283,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -11245,7 +11229,6 @@
       "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-5.14.0.tgz",
       "integrity": "sha512-O2ok6N/bQ9NA9nJ22r/PRQQYkUe9JwfDMjBPkQ+8OwsVH4TpA5skIAM2wc0k+rni5lVbAVONVyBvgi1rF2vEPA==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@mapbox/geojson-rewind": "^0.5.2",
         "@mapbox/jsonlint-lines-primitives": "^2.0.2",
@@ -13880,7 +13863,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -14427,7 +14409,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -15331,7 +15312,6 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -16152,7 +16132,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -16165,7 +16144,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -16222,7 +16200,6 @@
       "resolved": "https://registry.npmjs.org/@docusaurus/react-loadable/-/react-loadable-6.0.0.tgz",
       "integrity": "sha512-YMMxTUQV/QFSnbgrP3tjDzLHRg7vsbMn8e9HAa8o/1iXoiomo48b7sk/kkmWEuWNDPJVlKSJRB6Y2fHqdJk+SQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/react": "*"
       },
@@ -16251,7 +16228,6 @@
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
       "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.13",
         "history": "^4.9.0",
@@ -18029,7 +18005,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -18240,8 +18215,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/type-fest": {
       "version": "5.3.1",
@@ -18307,7 +18281,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -18670,7 +18643,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -18878,7 +18850,6 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.96.1.tgz",
       "integrity": "sha512-l2LlBSvVZGhL4ZrPwyr8+37AunkcYj5qh8o6u2/2rzoPc8gxFJkLj1WxNgooi9pnoc06jh0BjuXnamM4qlujZA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.6",
@@ -19154,7 +19125,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -19517,7 +19487,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.13.tgz",
       "integrity": "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/plugins/llm-txt-plugin.ts
+++ b/plugins/llm-txt-plugin.ts
@@ -4,15 +4,70 @@ import * as path from 'path';
 
 interface DocContent {
   title: string;
-  path: string;
+  description: string;
+  urlPath: string;
   content: string;
+  category: string;
 }
 
-function extractFrontmatter(content: string): { title: string; body: string } {
+// ============================================================
+// ADAPT THESE FOR YOUR SITE
+// ============================================================
+
+// Map directory names to display category names
+const CATEGORY_NAMES: Record<string, string> = {
+  'draw-modes': 'Draw Modes',
+  'edit-modes': 'Edit Modes',
+  'helper-modes': 'Helper Modes',
+};
+
+// Map standalone files (by URL slug) to categories
+const STANDALONE_CATEGORIES: Record<string, string> = {
+  'basics': 'Getting Started',
+  'configuring-geoman': 'Getting Started',
+  'events': 'Getting Started',
+  'mode-switching': 'Getting Started',
+  'importing-data': 'Data',
+  'exporting-data': 'Data',
+  'feature-ids': 'Data',
+  'examples': 'Other',
+  'geoman-instance-api': 'API Reference',
+  'geoman-options-api': 'API Reference',
+  'features-instance': 'API Reference',
+};
+
+// Category display order
+const CATEGORY_ORDER = [
+  'Getting Started',
+  'Draw Modes',
+  'Edit Modes',
+  'Helper Modes',
+  'Data',
+  'API Reference',
+  'Other',
+];
+
+// Site name and description for the llms.txt header
+const SITE_NAME = 'MapLibre-Geoman';
+const SITE_DESCRIPTION =
+  'MapLibre-Geoman is a MapLibre plugin for creating and editing geometry layers. It supports drawing, editing, dragging, cutting, rotating, splitting, scaling, measuring, snapping, and pinning markers, polygons, polylines, circles, rectangles, and more.';
+
+// ============================================================
+// GENERIC LOGIC BELOW — no changes needed
+// ============================================================
+
+function extractFrontmatter(content: string): {
+  title: string;
+  description: string;
+  slug: string;
+  body: string;
+} {
   const frontmatterRegex = /^---\s*\n([\s\S]*?)\n---\s*\n/;
   const match = content.match(frontmatterRegex);
 
   let title = '';
+  let description = '';
+  let slug = '';
   let body = content;
 
   if (match) {
@@ -21,10 +76,19 @@ function extractFrontmatter(content: string): { title: string; body: string } {
     if (titleMatch) {
       title = titleMatch[1].trim();
     }
+    const descMatch = frontmatter.match(
+      /description:\s*["']?([^"'\n]+)["']?/
+    );
+    if (descMatch) {
+      description = descMatch[1].trim();
+    }
+    const slugMatch = frontmatter.match(/slug:\s*["']?([^"'\n]+)["']?/);
+    if (slugMatch) {
+      slug = slugMatch[1].trim();
+    }
     body = content.slice(match[0].length);
   }
 
-  // Try to extract title from first heading if not in frontmatter
   if (!title) {
     const headingMatch = body.match(/^#\s+(.+)$/m);
     if (headingMatch) {
@@ -32,24 +96,101 @@ function extractFrontmatter(content: string): { title: string; body: string } {
     }
   }
 
-  return { title, body };
+  return { title, description, slug, body };
 }
 
 function stripMdxComponents(content: string): string {
+  // Preserve code blocks
+  const codeBlocks: string[] = [];
+  let cleaned = content.replace(/```[\s\S]*?```/g, (match) => {
+    codeBlocks.push(match);
+    return `__CODE_BLOCK_${codeBlocks.length - 1}__`;
+  });
+
   // Remove import statements
-  let cleaned = content.replace(/^import\s+.*$/gm, '');
+  cleaned = cleaned.replace(/^import\s+.*$/gm, '');
 
-  // Remove JSX/MDX components (self-closing and with children)
+  // Remove self-closing JSX components: <Component />
   cleaned = cleaned.replace(/<[A-Z][a-zA-Z]*[^>]*\/>/g, '');
-  cleaned = cleaned.replace(/<[A-Z][a-zA-Z]*[^>]*>[\s\S]*?<\/[A-Z][a-zA-Z]*>/g, '');
 
-  // Clean up excessive newlines
+  // Remove JSX component blocks (including multiline)
+  let prev = '';
+  while (prev !== cleaned) {
+    prev = cleaned;
+    cleaned = cleaned.replace(
+      /<([A-Z][a-zA-Z]*)[^>]*>[\s\S]*?<\/\1>/g,
+      ''
+    );
+  }
+
+  // Remove HTML image tags
+  cleaned = cleaned.replace(/<img[^>]*\/?>/gi, '');
+
+  // Remove markdown images (![alt](url))
+  cleaned = cleaned.replace(/!\[[^\]]*\]\([^)]+\)/g, '');
+
+  // Remove <details>/<summary> tags but keep inner content
+  cleaned = cleaned.replace(/<\/?details[^>]*>/gi, '');
+  cleaned = cleaned.replace(/<\/?summary[^>]*>/gi, '');
+
+  // Remove inline HTML div wrappers
+  cleaned = cleaned.replace(/<div[^>]*>/gi, '');
+  cleaned = cleaned.replace(/<\/div>/gi, '');
+
+  // Restore code blocks
+  cleaned = cleaned.replace(/__CODE_BLOCK_(\d+)__/g, (_, i) => codeBlocks[parseInt(i)]);
+
+  // Collapse multiple blank lines
   cleaned = cleaned.replace(/\n{3,}/g, '\n\n');
 
   return cleaned.trim();
 }
 
-function getAllMarkdownFiles(dir: string, baseDir: string = dir): DocContent[] {
+function stripLeadingHeading(content: string, title: string): string {
+  const normalizedTitle = title.replace(/[⭐\s]+$/g, '').trim().toLowerCase();
+  return content.replace(/^(#{1,6})\s+(.+)\n*/, (match, _hashes, heading) => {
+    const normalizedHeading = heading.replace(/[⭐\s]+$/g, '').trim().toLowerCase();
+    return normalizedHeading === normalizedTitle ? '' : match;
+  });
+}
+
+function computeUrlPath(relativePath: string, slug: string): string {
+  if (slug) {
+    return slug.replace(/^\//, '');
+  }
+
+  return (
+    relativePath
+      .replace(/\\/g, '/')
+      .replace(/\.mdx?$/, '')
+      // Strip numeric prefixes: "01-basics" → "basics", "03a-draw-ellipse" → "draw-ellipse"
+      .replace(/^\d+[a-z]?-/, '')
+      .replace(/\/\d+[a-z]?-/g, '/')
+      // Remove trailing "index"
+      .replace(/\/?index$/, '')
+  );
+}
+
+function getCategory(relativePath: string, urlPath: string): string {
+  const normalizedPath = relativePath.replace(/\\/g, '/');
+  const dir = normalizedPath.split('/')[0];
+
+  if (normalizedPath.includes('/') && CATEGORY_NAMES[dir]) {
+    return CATEGORY_NAMES[dir];
+  }
+
+  const slug = urlPath.replace(/\/$/, '');
+  if (STANDALONE_CATEGORIES[slug]) {
+    return STANDALONE_CATEGORIES[slug];
+  }
+
+  return '';
+}
+
+function getAllMarkdownFiles(
+  dir: string,
+  baseDir: string = dir
+): DocContent[] {
   const docs: DocContent[] = [];
 
   if (!fs.existsSync(dir)) {
@@ -66,22 +207,19 @@ function getAllMarkdownFiles(dir: string, baseDir: string = dir): DocContent[] {
       docs.push(...getAllMarkdownFiles(fullPath, baseDir));
     } else if (item.endsWith('.md') || item.endsWith('.mdx')) {
       const content = fs.readFileSync(fullPath, 'utf-8');
-      const { title, body } = extractFrontmatter(content);
+      const { title, description, slug, body } = extractFrontmatter(content);
       const cleanedContent = stripMdxComponents(body);
 
-      // Calculate relative path for URL
       const relativePath = path.relative(baseDir, fullPath);
-      const urlPath = relativePath
-        .replace(/\\/g, '/')
-        .replace(/\.mdx?$/, '')
-        .replace(/index$/, '')
-        .replace(/^\d+-/, '') // Remove numeric prefixes like "01-"
-        .replace(/\/\d+-/g, '/'); // Remove numeric prefixes in subdirs
+      const urlPath = computeUrlPath(relativePath, slug);
+      const category = getCategory(relativePath, urlPath);
 
       docs.push({
         title: title || path.basename(item, path.extname(item)),
-        path: urlPath,
+        description,
+        urlPath,
         content: cleanedContent,
+        category,
       });
     }
   }
@@ -89,62 +227,142 @@ function getAllMarkdownFiles(dir: string, baseDir: string = dir): DocContent[] {
   return docs;
 }
 
-function generateLlmTxt(docs: DocContent[], siteUrl: string, baseUrl: string): string {
-  const header = `# MapLibre-Geoman Documentation
+function generateLlmsIndex(
+  docs: DocContent[],
+  siteUrl: string,
+  baseUrl: string
+): string {
+  const fullUrl = (urlPath: string) =>
+    urlPath ? `${siteUrl}${baseUrl}/${urlPath}` : `${siteUrl}${baseUrl}`;
 
-> This file contains all documentation in a format optimized for LLMs.
-> Source: ${siteUrl}${baseUrl}
+  const grouped = new Map<string, DocContent[]>();
+  for (const doc of docs) {
+    if (!doc.category) continue;
+    if (!grouped.has(doc.category)) {
+      grouped.set(doc.category, []);
+    }
+    grouped.get(doc.category)!.push(doc);
+  }
 
-## Table of Contents
+  let output = `# ${SITE_NAME}\n\n> ${SITE_DESCRIPTION} Source: ${siteUrl}${baseUrl}\n\n`;
 
-${docs.map((doc, i) => `${i + 1}. [${doc.title}](#${doc.title.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '')})`).join('\n')}
+  for (const categoryName of CATEGORY_ORDER) {
+    const categoryDocs = grouped.get(categoryName);
+    if (!categoryDocs || categoryDocs.length === 0) continue;
 
----
+    output += `## ${categoryName}\n\n`;
 
-`;
+    for (const doc of categoryDocs) {
+      const desc = doc.description ? `: ${doc.description}` : '';
+      output += `- [${doc.title}](${fullUrl(doc.urlPath)})${desc}\n`;
+    }
 
-  const content = docs
-    .map((doc) => {
-      return `## ${doc.title}
+    output += '\n';
+  }
 
-**URL:** ${siteUrl}${baseUrl}/${doc.path}
+  return output.trim() + '\n';
+}
 
-${doc.content}
+function generateLlmsFull(
+  docs: DocContent[],
+  siteUrl: string,
+  baseUrl: string
+): string {
+  const fullUrl = (urlPath: string) =>
+    urlPath ? `${siteUrl}${baseUrl}/${urlPath}` : `${siteUrl}${baseUrl}`;
 
----
-`;
-    })
-    .join('\n');
+  let output = `# ${SITE_NAME} Documentation (Full)\n\n`;
+  output += `> Complete documentation for ${SITE_NAME}.\n`;
+  output += `> Source: ${siteUrl}${baseUrl}\n`;
+  output += `> Index: ${siteUrl}${baseUrl}/llms.txt\n\n---\n\n`;
 
-  return header + content;
+  for (const doc of docs) {
+    output += `## ${doc.title}\n\n`;
+    if (doc.description) {
+      output += `> ${doc.description}\n\n`;
+    }
+    output += `**URL:** ${fullUrl(doc.urlPath)}\n\n`;
+    output += `${stripLeadingHeading(doc.content, doc.title)}\n\n`;
+    output += `---\n\n`;
+  }
+
+  return output;
+}
+
+function generateAllFiles(
+  context: LoadContext,
+  outputDir: string,
+  options: { includeMdFiles: boolean }
+) {
+  const docsDir = path.join(context.siteDir, 'docs');
+  const docs = getAllMarkdownFiles(docsDir);
+
+  docs.sort((a, b) => a.urlPath.localeCompare(b.urlPath));
+
+  const siteUrl = context.siteConfig.url;
+  const baseUrl = context.siteConfig.baseUrl.replace(/\/$/, '');
+
+  const llmsIndex = generateLlmsIndex(docs, siteUrl, baseUrl);
+  fs.writeFileSync(path.join(outputDir, 'llms.txt'), llmsIndex, 'utf-8');
+
+  const llmsFull = generateLlmsFull(docs, siteUrl, baseUrl);
+  fs.writeFileSync(path.join(outputDir, 'llms-full.txt'), llmsFull, 'utf-8');
+
+  if (options.includeMdFiles) {
+    for (const doc of docs) {
+      if (!doc.urlPath) continue;
+
+      const mdOutputPath = path.join(outputDir, doc.urlPath + '.md');
+      fs.mkdirSync(path.dirname(mdOutputPath), { recursive: true });
+
+      const bodyContent = stripLeadingHeading(doc.content, doc.title);
+      let mdContent = `# ${doc.title}\n\n`;
+      if (doc.description) {
+        mdContent += `> ${doc.description}\n\n`;
+      }
+      mdContent += bodyContent + '\n';
+
+      fs.writeFileSync(mdOutputPath, mdContent, 'utf-8');
+    }
+  }
+
+  return docs.length;
 }
 
 export default function llmTxtPlugin(context: LoadContext): Plugin {
-  const generateAndSaveLlmTxt = (outputDir: string) => {
-    const docsDir = path.join(context.siteDir, 'docs');
-    const docs = getAllMarkdownFiles(docsDir);
-
-    // Sort docs by path for consistent ordering
-    docs.sort((a, b) => a.path.localeCompare(b.path));
-
-    const llmTxt = generateLlmTxt(
-      docs,
-      context.siteConfig.url,
-      context.siteConfig.baseUrl.replace(/\/$/, '')
-    );
-
-    const outputPath = path.join(outputDir, 'llms.txt');
-    fs.writeFileSync(outputPath, llmTxt, 'utf-8');
-
-    return docs.length;
-  };
-
   return {
     name: 'llm-txt-plugin',
 
-    async postBuild({ outDir }) {
-      const count = generateAndSaveLlmTxt(outDir);
-      console.log(`[llm-txt-plugin] Generated llms.txt with ${count} documents`);
+    // Generate to static/ so files are served during dev
+    async loadContent() {
+      const staticDir = path.join(context.siteDir, 'static');
+      generateAllFiles(context, staticDir, { includeMdFiles: false });
+      console.log('[llm-txt] Generated llms.txt and llms-full.txt in static/');
+    },
+
+    injectHtmlTags() {
+      return {
+        headTags: [
+          {
+            tagName: 'link',
+            attributes: {
+              rel: 'alternate',
+              type: 'text/markdown',
+              href: `${context.siteConfig.baseUrl}llms.txt`,
+            },
+          },
+        ],
+      };
+    },
+
+    // Generate full set (including per-page .md files) to build output
+    async postBuild(props) {
+      const count = generateAllFiles(context, props.outDir, {
+        includeMdFiles: true,
+      });
+      console.log(
+        `[llm-txt] Generated llms.txt, llms-full.txt, and ${count} .md files in build/`
+      );
     },
   };
 }

--- a/src/components/CopyAsMarkdown/index.tsx
+++ b/src/components/CopyAsMarkdown/index.tsx
@@ -10,17 +10,15 @@ export default function CopyAsMarkdown({ className }: CopyAsMarkdownProps): JSX.
 
   const handleCopy = useCallback(async () => {
     try {
-      // Get the current page's markdown source URL
-      const editUrl = document.querySelector<HTMLAnchorElement>('a[href*="github.com"][href*="/edit/"]');
+      // Try fetching the local .md file generated during build
+      const currentPath = window.location.pathname.replace(/\/$/, '');
+      const mdUrl = currentPath + '.md';
 
-      if (editUrl) {
-        // Convert edit URL to raw content URL
-        const rawUrl = editUrl.href
-          .replace('github.com', 'raw.githubusercontent.com')
-          .replace('/edit/', '/');
-
-        const response = await fetch(rawUrl);
-        if (response.ok) {
+      const response = await fetch(mdUrl);
+      if (response.ok) {
+        const contentType = response.headers.get('content-type') || '';
+        // Verify we got markdown, not an HTML 404 page
+        if (!contentType.includes('text/html')) {
           const markdown = await response.text();
           await navigator.clipboard.writeText(markdown);
           setCopied(true);


### PR DESCRIPTION
## Summary

Transforms the MapLibre-Geoman docs into a full llmstxt.org spec-compliant setup for LLM consumption. The enhanced plugin generates categorized `llms.txt` indices (Getting Started, Draw/Edit/Helper Modes, Data, API Reference), complete `llms-full.txt` dumps, per-page `.md` files for each doc, and auto-discovery link tags. The CopyAsMarkdown component now fetches local `.md` files instead of GitHub URLs. All 39 doc files receive frontmatter descriptions for SEO and llms.txt summaries, with proper categorization by directory structure.

## Changes

- **plugins/llm-txt-plugin.ts**: Complete rewrite (~328 lines) with categorized output, per-page files, and link tag injection
- **src/components/CopyAsMarkdown/index.tsx**: Updated to fetch local `.md` files with content-type validation
- **docs/** (39 files): Added `description` frontmatter to all doc files
- **.gitignore**: Added `/static/llms.txt` and `/static/llms-full.txt`
- **.npmrc**: Added NPM token configuration for private package registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)