### PR TITLE
Add lead capture CTAs to MapLibre docs

### DIFF
--- a/docs/01-basics.mdx
+++ b/docs/01-basics.mdx
@@ -3,6 +3,8 @@ title: "Basic Usage and Installation"
 description: "Installation guide, basic setup, and initialization for the free and pro versions of MapLibre-Geoman."
 ---
 
+import ProCallout from '@site/src/components/ProCallout';
+
 # Basic Usage
 
 ## Installation
@@ -33,7 +35,7 @@ Replace `<YOUR LICENSE KEY>` with your license key.
 npm install @geoman-io/maplibre-geoman-pro
 ```
 
-Don't have a license key yet? [Purchase one here](https://geoman.io/pricing).
+Don't have a license key yet? <a href="https://geoman.io/pricing" className="pro-cta-link">Purchase one here</a>.
 
 #### Installing the Pro Version on Vercel
 
@@ -57,6 +59,8 @@ To install the Pro version on Vercel, follow these steps:
 
 
 Once these variables are set, Vercel will use the correct .npmrc configuration and license key to access the Pro version.
+
+<ProCallout />
 
 ## Expected HTML Structure
 

--- a/docs/draw-modes/07-draw-freehand.mdx
+++ b/docs/draw-modes/07-draw-freehand.mdx
@@ -3,6 +3,8 @@ title: "Draw Freehand ⭐"
 description: "Draw freehand shapes on the map by clicking and dragging."
 ---
 
+import IntegrationHelpCallout from '@site/src/components/IntegrationHelpCallout';
+
 # Draw Freehand Mode ⭐
 
 Freehand Mode allows you to create freehand lines or shapes on the map by continuously dragging the mouse or touch input. This mode is ideal for drawing natural, flowing lines without the need to click for each vertex.
@@ -43,3 +45,5 @@ import BrowserOnlyGmMap from "../../src/components/map/BrowserOnlyGmMap";
 import { drawFreehandOptions } from "../../src/components/examples/mode-options.ts";
 
 <BrowserOnlyGmMap gmOptions={drawFreehandOptions} />
+
+<IntegrationHelpCallout />

--- a/docs/draw-modes/08-draw-custom_shape.mdx
+++ b/docs/draw-modes/08-draw-custom_shape.mdx
@@ -3,6 +3,8 @@ title: "Draw Custom Shape ⭐"
 description: "Draw custom predefined shapes like arrows or stars using GeoJSON templates."
 ---
 
+import IntegrationHelpCallout from '@site/src/components/IntegrationHelpCallout';
+
 # Draw Custom Shape Mode ⭐
 
 Custom Shape Mode allows you to create predefined shapes on the map by selecting from available options. This mode is ideal for adding consistent and reusable shapes without the need to manually define each vertex.
@@ -93,3 +95,5 @@ import BrowserOnlyGmMap from "../../src/components/map/BrowserOnlyGmMap";
 import { drawCustomShapeOptions } from "../../src/components/examples/mode-options";
 
 <BrowserOnlyGmMap gmOptions={drawCustomShapeOptions} />
+
+<IntegrationHelpCallout />

--- a/docs/edit-modes/03-edit-scale.mdx
+++ b/docs/edit-modes/03-edit-scale.mdx
@@ -3,6 +3,8 @@ title: "Scale ⭐"
 description: "Scale features to resize them proportionally."
 ---
 
+import IntegrationHelpCallout from '@site/src/components/IntegrationHelpCallout';
+
 # Scale Mode
 
 You can handle Scale Mode for all layers on a map like this:
@@ -63,3 +65,5 @@ import features from '../../src/components/examples/geojson/basic-edit.json';
 <BrowserOnlyGmMap
   gmOptions={editScaleOptions}
   features={features} />
+
+<IntegrationHelpCallout />

--- a/docs/edit-modes/04-edit-copy.mdx
+++ b/docs/edit-modes/04-edit-copy.mdx
@@ -3,6 +3,8 @@ title: "Copy ⭐"
 description: "Copy features to duplicate them on the map."
 ---
 
+import IntegrationHelpCallout from '@site/src/components/IntegrationHelpCallout';
+
 # Copy Mode
 
 You can handle Copy Mode for all layers on a map like this:
@@ -60,3 +62,5 @@ import features from '../../src/components/examples/geojson/basic-edit.json';
 <BrowserOnlyGmMap
   gmOptions={editCopyOptions}
   features={features} />
+
+<IntegrationHelpCallout />

--- a/docs/edit-modes/06-edit-split.mdx
+++ b/docs/edit-modes/06-edit-split.mdx
@@ -3,6 +3,8 @@ title: "Split ⭐"
 description: "Split features into multiple parts using a cutting line."
 ---
 
+import IntegrationHelpCallout from '@site/src/components/IntegrationHelpCallout';
+
 # Split Mode
 
 Split Mode allows you to draw a line that splits all underlying Polygons and Lines. When a feature is split, the original feature will be replaced with the resulting split features.
@@ -61,3 +63,5 @@ import features from '../../src/components/examples/geojson/basic-edit.json';
 <BrowserOnlyGmMap
   gmOptions={editSplitOptions}
   features={features} />
+
+<IntegrationHelpCallout />

--- a/docs/edit-modes/07-edit-union.mdx
+++ b/docs/edit-modes/07-edit-union.mdx
@@ -3,6 +3,8 @@ title: "Union ⭐"
 description: "Merge overlapping features into a single combined geometry."
 ---
 
+import IntegrationHelpCallout from '@site/src/components/IntegrationHelpCallout';
+
 # Union Mode
 
 Union Mode allows you to merge multiple polygons into a single polygon. The original features will be replaced with the resulting union feature.
@@ -68,3 +70,5 @@ import features from '../../src/components/examples/geojson/olverlapped-features
 <BrowserOnlyGmMap
   gmOptions={editUnionOptions}
   features={features} />
+
+<IntegrationHelpCallout />

--- a/docs/edit-modes/08-edit-difference.mdx
+++ b/docs/edit-modes/08-edit-difference.mdx
@@ -3,6 +3,8 @@ title: "Difference ⭐"
 description: "Compute the geometric difference between overlapping features."
 ---
 
+import IntegrationHelpCallout from '@site/src/components/IntegrationHelpCallout';
+
 # Difference Mode
 
 Difference Mode allows you to subtract one polygon from another. The original feature will be replaced with the resulting difference feature.
@@ -68,3 +70,5 @@ import features from '../../src/components/examples/geojson/olverlapped-features
 <BrowserOnlyGmMap
   gmOptions={editDifferenceOptions}
   features={features} />
+
+<IntegrationHelpCallout />

--- a/docs/edit-modes/09-edit-line_simplification.mdx
+++ b/docs/edit-modes/09-edit-line_simplification.mdx
@@ -3,6 +3,8 @@ title: "Line Simplification ⭐"
 description: "Simplify polyline and polygon vertices to reduce complexity."
 ---
 
+import IntegrationHelpCallout from '@site/src/components/IntegrationHelpCallout';
+
 # Line Simplification Mode
 
 Line Simplification Mode allows you to simplify line geometry by removing vertices. This is useful for smoothing complex lines or reducing the number of points in a line.
@@ -66,3 +68,5 @@ import features from '../../src/components/examples/geojson/basic-edit.json';
 <BrowserOnlyGmMap
   gmOptions={editLineSimplificationOptions}
   features={features} />
+
+<IntegrationHelpCallout />

--- a/docs/edit-modes/10-edit-lasso.mdx
+++ b/docs/edit-modes/10-edit-lasso.mdx
@@ -3,6 +3,8 @@ title: "Lasso ⭐"
 description: "Select multiple features by drawing a freehand lasso selection area."
 ---
 
+import IntegrationHelpCallout from '@site/src/components/IntegrationHelpCallout';
+
 # Lasso Mode
 
 Lasso Mode allows you to select multiple features by drawing a polygon around them. The selection behavior can be configured to either select features that intersect with or are contained within the lasso polygon.
@@ -64,3 +66,5 @@ import features from '../../src/components/examples/geojson/basic-edit.json';
 <BrowserOnlyGmMap
   gmOptions={editLassoOptions}
   features={features} />
+
+<IntegrationHelpCallout />

--- a/docs/helper-modes/01-helper-snap_guides.mdx
+++ b/docs/helper-modes/01-helper-snap_guides.mdx
@@ -3,6 +3,8 @@ title: "Snap Guides ⭐"
 description: "Display alignment guides when drawing or editing features."
 ---
 
+import IntegrationHelpCallout from '@site/src/components/IntegrationHelpCallout';
+
 # Snap Guides Helper Mode
 
 The Snap Guides Helper Mode adds visual guidelines that assist in snapping features to specific angles or points during map editing. This mode is useful when precise alignment is necessary while creating or modifying shapes.
@@ -58,3 +60,5 @@ import features from '../../src/components/examples/geojson/basic-edit.json';
 <BrowserOnlyGmMap
   gmOptions={helperSnapGuidesOptions}
   features={features} />
+
+<IntegrationHelpCallout />

--- a/docs/helper-modes/02-helper-measurements.mdx
+++ b/docs/helper-modes/02-helper-measurements.mdx
@@ -3,6 +3,8 @@ title: "Measurements ⭐"
 description: "Display live distance, area, and perimeter measurements during drawing and editing."
 ---
 
+import IntegrationHelpCallout from '@site/src/components/IntegrationHelpCallout';
+
 # Measurements Helper Mode
 
 The Measurements Helper Mode provides tools to display live measurements such as distance, area, and perimeter for various shapes during map editing. This mode works with different shape types to dynamically calculate and display measurements as users draw or modify features.
@@ -75,3 +77,5 @@ import features from '../../src/components/examples/geojson/basic-edit.json';
 <BrowserOnlyGmMap
   gmOptions={helperMeasurementsOptions}
   features={features} />
+
+<IntegrationHelpCallout />

--- a/docs/helper-modes/03-helper-pin.mdx
+++ b/docs/helper-modes/03-helper-pin.mdx
@@ -3,6 +3,8 @@ title: "Pin ⭐"
 description: "Pin markers to specific positions that persist across interactions."
 ---
 
+import IntegrationHelpCallout from '@site/src/components/IntegrationHelpCallout';
+
 # Pin Helper Mode
 
 The Pin Helper Mode allows you to "pin" markers or vertices together, enabling synchronized movement of all connected points when any one of them is dragged. This mode is useful for maintaining alignment across features that share the same coordinates.
@@ -48,3 +50,5 @@ import features from '../../src/components/examples/geojson/basic-edit.json';
 <BrowserOnlyGmMap
   gmOptions={helperPinOptions}
   features={features} />
+
+<IntegrationHelpCallout />

--- a/docs/helper-modes/04-helper-auto_trace.mdx
+++ b/docs/helper-modes/04-helper-auto_trace.mdx
@@ -3,6 +3,8 @@ title: "Auto Trace ⭐"
 description: "Automatically trace along existing feature edges when drawing new shapes."
 ---
 
+import IntegrationHelpCallout from '@site/src/components/IntegrationHelpCallout';
+
 # Auto Trace Helper Mode
 
 The Auto Trace Helper Mode assists users in drawing and connecting shapes by automatically tracing the shortest path between selected points. This mode can be applied to create or complete shapes like lines and polygons by tracing along existing paths.
@@ -54,3 +56,5 @@ import features from '../../src/components/examples/geojson/basic-edit.json';
 <BrowserOnlyGmMap
   gmOptions={helperAutoTraceOptions}
   features={features} />
+
+<IntegrationHelpCallout />

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -35,13 +35,20 @@ const config: Config = {
     defaultLocale: 'en',
     locales: ['en'],
   },
+  stylesheets: [
+    'https://geoman.io/embed/docs-lead-capture.css',
+  ],
   scripts: [
     {
       src: 'https://umami.parap.ly/script.js',
       'data-website-id': 'bc78fba3-4928-4efa-9923-03048345048e',
       defer: true,
       async: true,
-    }
+    },
+    {
+      src: 'https://geoman.io/embed/docs-lead-capture.js',
+      defer: true,
+    },
   ],
   plugins: [llmTxtPlugin],
 

--- a/src/components/IntegrationHelpCallout.js
+++ b/src/components/IntegrationHelpCallout.js
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export default function IntegrationHelpCallout() {
+  return (
+    <div className="docs-help-callout">
+      <p>
+        Building something complex?
+        Our team can help with architecture and integration.{' '}
+        <a href="mailto:sales@geoman.io?subject=Geoman%20Integration%20Help" className="consultation-link">
+          Get in touch →
+        </a>
+      </p>
+    </div>
+  );
+}

--- a/src/components/ProCallout.js
+++ b/src/components/ProCallout.js
@@ -1,0 +1,14 @@
+import React from 'react';
+
+export default function ProCallout() {
+  return (
+    <div className="docs-pro-callout">
+      <p>
+        Need help evaluating Pro for your team?{' '}
+        <a href="mailto:sales@geoman.io?subject=Geoman%20Pro%20Consultation" className="consultation-link">
+          Book a free 15-minute consultation →
+        </a>
+      </p>
+    </div>
+  );
+}

--- a/src/components/SidebarSignup.js
+++ b/src/components/SidebarSignup.js
@@ -1,0 +1,21 @@
+import React from 'react';
+
+export default function SidebarSignup() {
+  return (
+    <div className="docs-signup-sidebar">
+      <h4>Stay Updated</h4>
+      <p>Get changelog updates and Geoman tips.</p>
+      <form className="geoman-signup" data-placement="sidebar">
+        <input type="email" name="email" placeholder="you@company.com" required />
+        <input
+          type="text"
+          name="_hp"
+          style={{ position: 'absolute', left: '-9999px' }}
+          tabIndex={-1}
+          autoComplete="off"
+        />
+        <button type="submit">Subscribe</button>
+      </form>
+    </div>
+  );
+}

--- a/src/theme/DocItem/Footer/index.tsx
+++ b/src/theme/DocItem/Footer/index.tsx
@@ -1,0 +1,30 @@
+import React, {type ReactNode} from 'react';
+import Footer from '@theme-original/DocItem/Footer';
+import type FooterType from '@theme/DocItem/Footer';
+import type {WrapperProps} from '@docusaurus/types';
+
+type Props = WrapperProps<typeof FooterType>;
+
+export default function FooterWrapper(props: Props): ReactNode {
+  return (
+    <>
+      <div className="docs-signup-footer">
+        <h4>Found this helpful?</h4>
+        <p>Subscribe for changelog updates, tips, and new feature announcements.</p>
+        <form className="geoman-signup" data-placement="page-footer">
+          <input type="email" name="email" placeholder="you@company.com" required />
+          <input type="text" name="name" placeholder="Name (optional)" />
+          <input
+            type="text"
+            name="_hp"
+            style={{ position: 'absolute', left: '-9999px' }}
+            tabIndex={-1}
+            autoComplete="off"
+          />
+          <button type="submit">Subscribe</button>
+        </form>
+      </div>
+      <Footer {...props} />
+    </>
+  );
+}

--- a/src/theme/DocSidebar/Desktop/Content/index.tsx
+++ b/src/theme/DocSidebar/Desktop/Content/index.tsx
@@ -1,0 +1,16 @@
+import React, {type ReactNode} from 'react';
+import Content from '@theme-original/DocSidebar/Desktop/Content';
+import type ContentType from '@theme/DocSidebar/Desktop/Content';
+import type {WrapperProps} from '@docusaurus/types';
+import SidebarSignup from '@site/src/components/SidebarSignup';
+
+type Props = WrapperProps<typeof ContentType>;
+
+export default function ContentWrapper(props: Props): ReactNode {
+  return (
+    <>
+      <Content {...props} />
+      <SidebarSignup />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- Added newsletter signup forms in sidebar and page footer with external docs-lead-capture.js/css
- Added Pro consultation callout on the Pro Version installation page
- Added integration help callouts to all 13 Pro/⭐ feature pages
- Updated .npmrc with environment variable auth token for Vercel deployment
- Renamed docs/01-basics.md to .mdx to support JSX imports

## Implementation Details
- Created three reusable components: SidebarSignup, ProCallout, IntegrationHelpCallout
- Swizzled DocSidebar/Desktop/Content and DocItem/Footer theme wrappers to inject components
- Updated docusaurus.config.ts to load external stylesheets and scripts from geoman.io
- All 13 Pro pages (split, scale, union, difference, copy, line simplification, lasso, custom shapes, freehand, pinning, measurements, autotracing, snap guides) now have integration help callout

🤖 Generated with Claude Code